### PR TITLE
fix: Skip `/workspaces/#{workspace_name}/rooms` with `'q': null` in body

### DIFF
--- a/lib/workspace.rb
+++ b/lib/workspace.rb
@@ -19,6 +19,8 @@ module NeWorkNotify
     def room_update(body)
       case body['p']
       when %r{^workspaces/.+/rooms$}
+        return if body['d'].nil?
+
         @rooms = {}
         body['d'].each do |k, v|
           @rooms[k] = Room.new(k, v, @name)


### PR DESCRIPTION
Tokenがexpireした際にルームの情報が来ない場合の処理を追加